### PR TITLE
Add templatized systemd service unit file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,25 @@ Now enable the `nzyme` service to make it start on boot of the Raspberry Pi:
 $ sudo systemctl enable nzyme
 ```
 
+Alterntively, you can use the templatized systemd service unit. This method handles setting a interface into monitor mode when started, managed mode when stopped, and uses a per-device configuration file. Configuration files must ffollow this naming convention ```/etc/nzyme/nzyme-NIC.conf``` where NIC is replaced with the name of your wireless device (not phy0, but something like wlan0). NOTE: currently nzyme does not support logging to unique filenames. The contents of the log file, when using the service templates, may be corrupt dependent on a variety of circumstances.
+
+```
+$ sudo systemctl enable nzyme@wlan0
+```
+
+
 Because we are not rebooting, we have to start the service manually for once:
 
 ```
 $ sudo systemctl start nzyme
 $ sudo systemctl status nzyme
+```
+
+Or, if you chose to use the systemd service template, this starts the service, including putting the interface into monitor mode, and checks the status.
+
+```
+$ sudo systemctl start nzyme@wlan0
+$ sudo systemctl status nzyme@wlan0
 ```
 
 ![Result of systemctl status](https://github.com/lennartkoopmann/nzyme/blob/master/systemctl-status.png)

--- a/pom.xml
+++ b/pom.xml
@@ -307,6 +307,18 @@
                                 </data>
 
                                 <data>
+                                    <src>src/deb/systemd/nzyme@.service</src>
+                                    <type>file</type>
+                                    <mapper>
+                                        <type>perm</type>
+                                        <prefix>/usr/lib/systemd/system</prefix>
+                                        <filemode>644</filemode>
+                                        <user>root</user>
+                                        <group>root</group>
+                                    </mapper>
+                                </data>
+
+                                <data>
                                     <src>src/deb/systemd/nzyme</src>
                                     <type>file</type>
                                     <mapper>

--- a/src/deb/systemd/nzyme@.service
+++ b/src/deb/systemd/nzyme@.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Nzyme
+Documentation=https://github.com/lennartkoopmann/nzyme
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=10
+User=root
+Group=root
+LimitNOFILE=64000
+ExecStartPre=/sbin/ip link set %i down
+ExecStartPre=/sbin/iw dev %i set type monitor
+ExecStartPre=/sbin/ip link set %i up
+ExecStart=/etc/alternatives/java -jar -Dlog4j.configurationFile=file:///etc/nzyme/log4j2-debian.xml /usr/share/nzyme/nzyme.jar --config-file /etc/nzyme/nzyme-%i.conf
+ExecStopPost=/sbin/ip link set %i down
+ExecStopPost=/sbin/iw dev %i set type managed
+
+# When a JVM receives a SIGTERM signal it exits with 143.
+SuccessExitStatus=143
+
+# Make sure stderr/stdout is captured in the systemd journal.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
systemd templates make it possible to pass
a parameter into a unit file when it is activated.
This allows us to do two things in nzyme:

1. Pass interface information into the unit.
If you only use the template once, this still provides
value as you can pass in a wireless interface without
modifying the unit file directly.

2. Untested: you can run multiple
instances of nzyme, one per NIC, to have the
same benefits apply to multiple interfaces,
like wlan0, wlan1, etc.

To enable a templatized unit you do something like:
systemctl enable nzyme@wlan0.service

Then to start it:
systemctl start nzyme@wlan0.service

This new unit file also adds support for
putting the interface into monitor mode on
startup and puts it into managed mode on
shutdown.